### PR TITLE
chore(deps): bump jackson.version from 2.8.6 to 2.12.1 in /servers/rest

### DIFF
--- a/servers/rest/pom.xml
+++ b/servers/rest/pom.xml
@@ -31,7 +31,7 @@
 		<vertx.version>3.5.0</vertx.version>
 		<influxdb.version>2.7</influxdb.version>
 		<jsonvaldiator.version>0.1.7</jsonvaldiator.version>
-		<jackson.version>2.8.6</jackson.version>
+		<jackson.version>2.12.1</jackson.version>
 		<ppmpjavabinding.version>0.3.0-SNAPSHOT</ppmpjavabinding.version>
 		<ppmpschema.version>3.0.0-SNAPSHOT</ppmpschema.version>
 		<log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
Bumps `jackson.version` from 2.8.6 to 2.12.1.

Updates `jackson-core` from 2.8.6 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.8.6...jackson-core-2.12.1)

Updates `jackson-databind` from 2.8.6 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Signed-off-by: dependabot[bot] <support@github.com>