### PR TITLE
chore(deps-dev): bump commons-io from 2.5 to 2.7 in /servers/rest

### DIFF
--- a/servers/rest/pom.xml
+++ b/servers/rest/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.5</version>
+			<version>2.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Bumps commons-io from 2.5 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>